### PR TITLE
Fix up the `command-not-found` feedback provider to work with Ubuntu 22.04 and 24.04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ project.lock.json
 # Ignore binaries and symbols
 *.pdb
 *.dll
-
+*.sln

--- a/src/FeedbackProvider.cs
+++ b/src/FeedbackProvider.cs
@@ -100,7 +100,7 @@ public sealed class LinuxCommandNotFound : IFeedbackProvider, ICommandPredictor
 
                     if (line.StartsWith("sudo ", StringComparison.Ordinal))
                     {
-                        (actions ??= []).Add(line.TrimEnd());;
+                        (actions ??= []).Add(line.TrimEnd());
                     }
                     else if (line.StartsWith("  "))
                     {

--- a/src/FeedbackProvider.cs
+++ b/src/FeedbackProvider.cs
@@ -100,8 +100,7 @@ public sealed class LinuxCommandNotFound : IFeedbackProvider, ICommandPredictor
 
                     if (line.StartsWith("sudo ", StringComparison.Ordinal))
                     {
-                        actions ??= [];
-                        actions.Add(line.TrimEnd());
+                        (actions ??= []).Add(line.TrimEnd());;
                     }
                     else if (line.StartsWith("  "))
                     {

--- a/src/FeedbackProvider.cs
+++ b/src/FeedbackProvider.cs
@@ -119,7 +119,10 @@ public sealed class LinuxCommandNotFound : IFeedbackProvider, ICommandPredictor
                         {
                             string package = GetPackageName(line, index + 6);
                             (actions ??= []).Add(line.Trim());
-                            (_candidates ??= []).Add($"sudo snap install {package}");
+
+                            _candidates ??= [];
+                            _candidates.Add($"snap info {package}");
+                            _candidates.Add($"sudo snap install {package}");
                         }
                     }
                     else

--- a/src/FeedbackProvider.cs
+++ b/src/FeedbackProvider.cs
@@ -117,10 +117,11 @@ public sealed class LinuxCommandNotFound : IFeedbackProvider, ICommandPredictor
                          * Command 'sshd' not found, but can be installed with:
                          * sudo apt install openssh-server
                         */
-                        actions ??= [];
+                        (actions ??= []).Add(line.TrimEnd());
 
                         // Remove the ending comment about the package version.
                         line = line.Split('#', StringSplitOptions.TrimEntries)[0];
+                        _candidates ??= [];
 
                         // 5 = "sudo ".Length
                         var rest = line.AsSpan(5);
@@ -128,14 +129,14 @@ public sealed class LinuxCommandNotFound : IFeedbackProvider, ICommandPredictor
                         {
                             // 13 = "snap install ".Length
                             string package = GetPackageName(rest[13..]);
-                            actions.Add($"snap info {package}");
+                            _candidates.Add($"snap info {package}");
                         }
                         else if (rest.StartsWith("apt  install", StringComparison.Ordinal))
                         {
                             line = line.Replace("apt  install", "apt install");
                         }
 
-                        actions.Add(line);
+                        _candidates.Add(line);
                     }
                     else if (line.StartsWith("  "))
                     {

--- a/src/PowerShell.CommandNotFound.Feedback.csproj
+++ b/src/PowerShell.CommandNotFound.Feedback.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Management.Automation" Version="7.4.0-preview.3">
+    <PackageReference Include="System.Management.Automation" Version="7.4.12">
       <ExcludeAssets>contentFiles</ExcludeAssets>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Fix up the `command-not-found` feedback provider to work with Ubuntu 22.04 and 24.04.
- Update build to use v7.4.12 `System.Management.Automation` package. The old preview package doesn't work anymore.
- Update parsing of the output from `command-not-found` tool to work with Ubuntu 22.04 and 24.04.

